### PR TITLE
ci: Update GitHub funding information

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: EvilBit-Labs


### PR DESCRIPTION
This pull request adds a GitHub Sponsors configuration to the repository by updating the `.github/FUNDING.yml` file.

- Repository configuration:
  * Added a `github` sponsor entry with the value `EvilBit-Labs` to `.github/FUNDING.yml`.